### PR TITLE
Upgrade cloud-sql-proxy v1.20.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM nownabe/watchkiller:1.1 AS watchkiller
 
-FROM gcr.io/cloudsql-docker/gce-proxy:1.13
+FROM gcr.io/cloudsql-docker/gce-proxy:1.20.2
 
 COPY --from=watchkiller /watchkiller /watchkiller
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.13
+VERSION := 1.20.2
 
 .PHONY: push
 push: build

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ spec:
               mountPath: /tmp/watchkiller
 
         - name: cloudsql-proxy
-          image: gcr.io/my-project/sqlproxy:1.13
+          image: gcr.io/my-project/sqlproxy:1.20.2
           command:
             - "/watchkiller"
             - "/cloud_sql_proxy"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ spec:
             - "/cloud_sql_proxy"
             - "-instances=my-project:asia-northeast1:mydb=tcp:3306"
             - "-credential_file=/secrets/cloudsql/credentials.json"
+            - "-log_debug_stdout=true"
           volumeMounts:
             - name: cloudsql-instance-credentials
               mountPath: /secrets/cloudsql


### PR DESCRIPTION
## Issue

- [SQL connection in Rake Pod is disconnected · Issue #151 · Wondershake/sre](https://github.com/Wondershake/sre/issues/151)

## 概要

- rake podでsql connectionの切断が断続的に発生
- cloud-sql-proxyのverisonが非常に古いため、一旦他のpodで使用しているverisonまでupgrade

## 変更内容

- cloud-sql-proxy
    - 1.13 -> 1.20.2
        - build/pushはlocalより実施済み
            - https://github.com/Wondershake/sre/issues/151#issuecomment-1180062265
        - 1.20.2までは別issueで内容確認済み
            - [K8s_Update cloudsql-proxy to 1.20.2 · Issue #48 · Wondershake/sre](https://github.com/Wondershake/sre/issues/48)
    - log_debug_stdout
        - 他のpodと同様に追加。通常のlogをerrとして出さないように設定。

## 影響範囲

- 無し

## 動作要件

無し

## 補足

無し

